### PR TITLE
Makes it easier to customise pagination

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,69 @@
+# Wagtail Library [![Build Status](https://travis-ci.com/omni-digital/omni-wagtail-library.svg?token=9QKsFUYHUxekS7Q4cLHs&branch=master)](https://travis-ci.com/omni-digital/omni-wagtail-library)
+
+A wagtail library for creating a library of documents or files for distribution from your website
+
+## Requirements
+
+Wagtail Library requires Django 1.10 or later and Wagtail 1.11 or later.
+
+## Supported Versions
+
+Python: 2.7, 3.4, 3.5, 3.6
+
+Django: 1.10, 1.11
+
+Wagtail: 1.11, 1.12
+
+## Getting started
+
+Installing from pip:
+
+```
+pip install wagtail-library
+```
+
+Adding to `INSTALLED_APPS`:
+
+```python
+INSTALLED_APPS = [
+    ...
+    'wagtail_library',
+    ...
+]
+```
+
+Running the migrations:
+
+```
+python manage migrate wagtail_library
+```
+
+## Models
+
+### LibraryIndex
+
+An index/listing page for library detail pages.
+
+### LibraryDetail
+
+A detail page for a library item
+
+## Overriding pagination
+
+If you decide to provide your own concrete implementation of the LibraryIndex (by subclassing AbstractLibraryIndex) you may override the pagination class.
+
+The simplest way of achieving this is to assign your paginator class using the `paginator_class` attribute on your model.
+
+More fine grained control can be achieved by overriding the following methods:
+
+ - `get_paginator_class` - Should return the paginator class to be used by the listing page.  Returns `Model.paginator_class` (djangos core paginator class) by default
+ - `get_paginator_kwargs` - If your custom paginator's constructor accepts extra keyword args this method can be overridden to provide them.  Returns a dictionary of keyword args to pass to the paginator constructor (An empty dictionary by default)
+ - `get_paginator` - Accepts a queryset or iterable, page count (number of results per page) and any keyword arguments returned by `get_paginator_kwargs`. Should return a paginator instance.
+ - `paginate_queryset` - Handles pagination of a queryset. Accepts a queryset or iterable, and the page number being requested. Returns a tuple: (PaginatorPage, Paginator)
+
+## Warranty
+
+
+*THIS SOFTWARE IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE ENTIRE RISK AS TO THE USE OF THIS SOFTWARE IS WITH YOU.*
+
+*IN NO EVENT WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR REDISTRIBUTE THE LIBRARY, BE LIABLE TO YOU FOR ANY DAMAGES, EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.*

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 django==1.11.3
+mock==2.0.0
 wagtail==1.11.1
 wagtail-factories==0.3.0

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ deps =
     mock==2.0.0
     psycopg2==2.7.1
     wagt111: wagtail>=1.11,<1.12
-    wagt111: wagtail>=1.12,<1.13
+    wagt112: wagtail>=1.12,<1.13
     wagtail-factories==0.3.0
 
 [testenv:py35-flake8]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,34,35,36}-dj{18,19,110,111}-wag{18,19,110,111},py36-flake8
+envlist = py{27,34,35,36}-dj{110,111}-wag{111,112},py36-flake8
 
 [testenv]
 setenv = PYTHONPATH = {toxinidir}:{toxinidir}/wagtail_library
@@ -8,17 +8,13 @@ commands =
     coverage report --show-missing
 deps =
     coverage==4.2.0
-    dj18: Django>=1.8,<1.9
-    dj19: Django>=1.9,<1.10
     dj110: Django>=1.10,<1.11
     dj111: Django>=1.11,<1.12
     factory-boy==2.8.1
     mock==2.0.0
     psycopg2==2.7.1
-    wag18: wagtail>=1.8,<1.9
-    wagt19: wagtail>=1.9,<1.10
-    wagt110: wagtail>=1.10,<1.11
     wagt111: wagtail>=1.11,<1.12
+    wagt111: wagtail>=1.12,<1.13
     wagtail-factories==0.3.0
 
 [testenv:py35-flake8]

--- a/wagtail_library/__init__.py
+++ b/wagtail_library/__init__.py
@@ -3,4 +3,4 @@
 from __future__ import unicode_literals
 
 
-__version__ = '1.0.0'
+__version__ = '1.1.0'


### PR DESCRIPTION
# Problems

It's not particularly easy to customise the pagination used in conjunction with this library.  For example, if we wanted to use a different pagination class we would need to override the entirety of the _paginate_queryset method which is likely to become cumbersome.

The pagination related methods on the Listing model are also private.  These should be customisable, so have been made public.

# Solution

Add extra pagination related methods to make it easier to change the pagination class and instantiation kwargs.

Also removed redundant wagtail and django versions we're testing against

# Note

This update has the potential to break existing integrations (specifically, the method names being made public).  I have looked over existing projects that depend on this lib and am confident that this update will not cause issues with upgrades.  However, if anyone is aware of anywhere that this will break compatibility please let me know.