### PR TITLE
Upgrade pyyaml specifically to avoid security vulnerability

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -10,6 +10,7 @@ pre-commit = ">=1.14.4,<1.15"
 pytest = "==4.3.0"
 pytest-django = "==3.4.8"
 wagtail-factories = "==1.1.0"
+pyyaml = "==4.2b1"
 
 [packages]
 wagtail = "==2.4"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "68491d1d0d02bbbf612b255c53727651c209501f434afd4644bb1ec0aca8ba5f"
+            "sha256": "cdbacbd6546a8b5189647f7a2d48145cfe5ff231262721e1c7d0cb91ca46981e"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -504,19 +504,10 @@
         },
         "pyyaml": {
             "hashes": [
-                "sha256:3d7da3009c0f3e783b2c873687652d83b1bbfd5c88e9813fb7e5b03c0dd3108b",
-                "sha256:3ef3092145e9b70e3ddd2c7ad59bdd0252a94dfe3949721633e41344de00a6bf",
-                "sha256:40c71b8e076d0550b2e6380bada1f1cd1017b882f7e16f09a65be98e017f211a",
-                "sha256:558dd60b890ba8fd982e05941927a3911dc409a63dcb8b634feaa0cda69330d3",
-                "sha256:a7c28b45d9f99102fa092bb213aa12e0aaf9a6a1f5e395d36166639c1f96c3a1",
-                "sha256:aa7dd4a6a427aed7df6fb7f08a580d68d9b118d90310374716ae90b710280af1",
-                "sha256:bc558586e6045763782014934bfaf39d48b8ae85a2713117d16c39864085c613",
-                "sha256:d46d7982b62e0729ad0175a9bc7e10a566fc07b224d2c79fafb5e032727eaa04",
-                "sha256:d5eef459e30b09f5a098b9cea68bebfeb268697f78d647bd255a085371ac7f3f",
-                "sha256:e01d3203230e1786cd91ccfdc8f8454c8069c91bee3962ad93b87a4b2860f537",
-                "sha256:e170a9e6fcfd19021dd29845af83bb79236068bf5fd4df3327c1be18182b2531"
+                "sha256:ef3a0d5a5e950747f4a39ed7b204e036b37f9bddc7551c1a813b8727515a832e"
             ],
-            "version": "==3.13"
+            "index": "pypi",
+            "version": "==4.2b1"
         },
         "requests": {
             "hashes": [


### PR DESCRIPTION
# Upgrade `pyyaml` to avoid security vulnerability

A potential security vulnerability linked to versions of `pyyaml < 4.2b1` has been found and flagged by GitHub's dependency analysis. This PR pins `pyyaml==4.2b1` to ensure that this is no longer an issue. `pyyaml` is only used by `pre-commit` in this project, and no significant changes are observed in the behaviour of pre-commit after the upgrade.